### PR TITLE
Update config, publish errors

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,4 @@
 ---
-version: '3'
 services:
   mosquitto:
     container_name: mosquitto

--- a/example.config.yaml
+++ b/example.config.yaml
@@ -2,7 +2,9 @@ logging:
   level: debug
 mqtt:
   broker_url: "tcp://mosquitto:1883"
-  command_topic: "cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/#"
+  write_command_topic: "cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/standby"
+  read_command_topic: "cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/cloud"
   standby_topic: "cmd/${SITE_NAME}/standby/${SERIAL_NUMBER}/plan"
+  error_topic: "dt/${SITE_NAME}/error/${SERIAL_NUMBER}"
 standby:
   backup_file: "plan.json"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,8 +26,8 @@ type LoggingConfig struct {
 
 type MQTTConfig struct {
 	BrokerURL         string `yaml:"broker_url" default:"tcp://localhost:1883/"`
-	WriteCommandTopic string `yaml:"command_topic" default:"cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/cloud"`
-	ReadCommandTopic  string `yaml:"command_topic" default:"cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/standby"`
+	WriteCommandTopic string `yaml:"write_command_topic" default:"cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/standby"`
+	ReadCommandTopic  string `yaml:"read_command_topic" default:"cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/cloud"`
 	StandbyTopic      string `yaml:"standby_topic" default:"cmd/${SITE_NAME}/standby/${SERIAL_NUMBER}/#"`
 	ErrorTopic        string `yaml:"error_topic" default:"dt/${SITE_NAME}/error/${SERIAL_NUMBER}"`
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,9 +25,11 @@ type LoggingConfig struct {
 }
 
 type MQTTConfig struct {
-	BrokerURL    string `yaml:"broker_url" default:"tcp://localhost:1883/"`
-	CommandTopic string `yaml:"command_topic" default:"cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/#"`
-	StandbyTopic string `yaml:"standby_topic" default:"cmd/${SITE_NAME}/standby/${SERIAL_NUMBER}/#"`
+	BrokerURL         string `yaml:"broker_url" default:"tcp://localhost:1883/"`
+	WriteCommandTopic string `yaml:"command_topic" default:"cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/cloud"`
+	ReadCommandTopic  string `yaml:"command_topic" default:"cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/standby"`
+	StandbyTopic      string `yaml:"standby_topic" default:"cmd/${SITE_NAME}/standby/${SERIAL_NUMBER}/#"`
+	ErrorTopic        string `yaml:"error_topic" default:"dt/${SITE_NAME}/error/${SERIAL_NUMBER}"`
 }
 
 type StandbyConfig struct {
@@ -66,14 +68,15 @@ func FromFile() (Config, error) {
 		return Config{}, fmt.Errorf("unable to parse config: %w", err)
 	}
 
-	cfg.interpolateEnvVars()
+	cfg.InterpolateEnvVars()
 
 	return cfg, nil
 }
 
-func (cfg *Config) interpolateEnvVars() {
-	cfg.MQTT.CommandTopic = strings.Replace(cfg.MQTT.CommandTopic, "${SITE_NAME}", cfg.SiteName, -1)
-	cfg.MQTT.CommandTopic = strings.Replace(cfg.MQTT.CommandTopic, "${SERIAL_NUMBER}", cfg.SerialNumber, -1)
-	cfg.MQTT.StandbyTopic = strings.Replace(cfg.MQTT.StandbyTopic, "${SITE_NAME}", cfg.SiteName, -1)
-	cfg.MQTT.StandbyTopic = strings.Replace(cfg.MQTT.StandbyTopic, "${SERIAL_NUMBER}", cfg.SerialNumber, -1)
+func (cfg *Config) InterpolateEnvVars() {
+	replacer := strings.NewReplacer("${SITE_NAME}", cfg.SiteName, "${SERIAL_NUMBER}", cfg.SerialNumber)
+	cfg.MQTT.ReadCommandTopic = replacer.Replace(cfg.MQTT.ReadCommandTopic)
+	cfg.MQTT.WriteCommandTopic = replacer.Replace(cfg.MQTT.WriteCommandTopic)
+	cfg.MQTT.StandbyTopic = replacer.Replace(cfg.MQTT.StandbyTopic)
+	cfg.MQTT.ErrorTopic = replacer.Replace(cfg.MQTT.ErrorTopic)
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -8,27 +8,26 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-/*
-func getTestConfigFromEnv(t *testing.T) config.Config {
-	t.Setenv("MQTT_BROKER_URL", "tcp://localhost:1883")
-	t.Setenv("MQTT_STANDBY_TOPIC", "cmd/site/standby/serial/#")
-
-	cfg, err := config.FromEnv()
-	assert.NoError(t, err)
-	return cfg
-}
-*/
-
 func getTestConfig() config.Config {
 	return config.Config{
+		SiteName:     "test",
+		SerialNumber: "device",
 		MQTT: config.MQTTConfig{
 			BrokerURL:    "tcp://localhost:1833",
-			StandbyTopic: "cmd/site/standby/serial/#",
+			StandbyTopic: "cmd/${SITE_NAME}/standby/${SERIAL_NUMBER}/#",
 		},
 	}
 }
 
-func TestReadConfig(t *testing.T) {
+func TestInterpolateVars(t *testing.T) {
 	cfg := getTestConfig()
 	assert.NotEmpty(t, cfg)
+
+	assert.Contains(t, cfg.MQTT.StandbyTopic, "${SITE_NAME}")
+	assert.Contains(t, cfg.MQTT.StandbyTopic, "${SERIAL_NUMBER}")
+
+	cfg.InterpolateEnvVars()
+	assert.NotContains(t, cfg.MQTT.StandbyTopic, "${SITE_NAME}")
+	assert.NotContains(t, cfg.MQTT.StandbyTopic, "${SERIAL_NUMBER}")
+	assert.EqualValues(t, cfg.MQTT.StandbyTopic, "cmd/test/standby/device/#")
 }

--- a/tests/integration/config.yaml
+++ b/tests/integration/config.yaml
@@ -2,7 +2,8 @@ logging:
   level: debug
 mqtt:
   broker_url: "tcp://mosquitto:1883"
-  command_topic: "cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/#"
+  write_command_topic: "cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/#"
+  read_command_topic: "cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/#"
   standby_topic: "cmd/${SITE_NAME}/standby/${SERIAL_NUMBER}/plan"
 standby:
   backup_file: "/command-standby/backup/plan.json"


### PR DESCRIPTION
- Publish errors to MQTT the same way remote-command-handler does
- Differentiate read and write command topics, we'll need to read from one and write to another