### PR TITLE
Add command replay during outage

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,8 +10,9 @@ import (
 )
 
 // Config holds all configurable values of the service.
-// It can contain values specified either in the environment or by file,
-// but file-based values cannot be required.
+// It can contain values specified either in the environment or by file.
+// File-based values are loaded in a two-step process, after env vars,
+// so they cannot be configured with required:true
 type Config struct {
 	SiteName          string        `env:"SITE_NAME" required:"true"`
 	SerialNumber      string        `env:"SERIAL_NUMBER" required:"true"`
@@ -31,6 +32,7 @@ type MQTTConfig struct {
 	ReadCommandTopic  string `yaml:"read_command_topic" default:"cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/cloud"`
 	StandbyTopic      string `yaml:"standby_topic" default:"cmd/${SITE_NAME}/standby/${SERIAL_NUMBER}/#"`
 	ErrorTopic        string `yaml:"error_topic" default:"dt/${SITE_NAME}/error/${SERIAL_NUMBER}"`
+	CommandAction     string `yaml:"command_action" default:"SETPOINT"`
 }
 
 type StandbyConfig struct {

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -44,8 +44,12 @@ type OptimisationValue struct {
 	Unit  int     `json:"unit"`
 }
 
-func (o OptimisationPlan) IsEmpty(logger *slog.Logger) bool {
+func (o OptimisationPlan) IsEmpty() bool {
 	return o.SiteID == "" && len(o.OptimisationIntervals) == 0 && o.OptimisationTimestamp.Seconds == 0
+}
+
+func (o OptimisationInterval) IsEmpty() bool {
+	return o.Interval.StartTime.Seconds == 0
 }
 
 func NewHandler(logger *slog.Logger, path string) PlanHandler {

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -11,7 +11,7 @@ import (
 
 type Handler struct {
 	logger *slog.Logger
-	mu     *sync.Mutex
+	mu     *sync.RWMutex
 	Path   string `required:"True"`
 }
 
@@ -62,7 +62,7 @@ func (i OptimisationInterval) IsCurrent(targetTime time.Time) bool {
 }
 
 func NewHandler(logger *slog.Logger, path string) Handler {
-	return Handler{logger: logger, mu: new(sync.Mutex), Path: path}
+	return Handler{logger: logger, mu: new(sync.RWMutex), Path: path}
 }
 
 func (p Handler) ReadPlan() (OptimisationPlan, error) {

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -109,6 +109,9 @@ func (p PlanHandler) TrimPlan(targetTime time.Time) error {
 	}
 
 	// If all intervals are in the future, exit without action
+	if len(plan.OptimisationIntervals) == 0 {
+		return nil
+	}
 	firstStart := plan.OptimisationIntervals[0].Interval
 	if firstStart.StartTime.Seconds > targetTime.Unix() {
 		return nil

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -12,7 +12,7 @@ import (
 type Handler struct {
 	logger *slog.Logger
 	mu     *sync.RWMutex
-	Path   string `required:"True"`
+	path   string
 }
 
 type OptimisationPlan struct {
@@ -62,14 +62,14 @@ func (i OptimisationInterval) IsCurrent(targetTime time.Time) bool {
 }
 
 func NewHandler(logger *slog.Logger, path string) Handler {
-	return Handler{logger: logger, mu: new(sync.RWMutex), Path: path}
+	return Handler{logger: logger, mu: new(sync.RWMutex), path: path}
 }
 
 func (p Handler) ReadPlan() (OptimisationPlan, error) {
 	p.mu.RLock()
 	defer p.mu.RUnlock()
 
-	content, err := os.ReadFile(p.Path)
+	content, err := os.ReadFile(p.path)
 	if err != nil {
 		return OptimisationPlan{}, fmt.Errorf("reading plan from file: %w", err)
 	}
@@ -86,9 +86,9 @@ func (p Handler) WritePlan(optPlan OptimisationPlan) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	f, err := os.Create(p.Path)
+	f, err := os.Create(p.path)
 	if err != nil {
-		return fmt.Errorf("creating plan backup file at %s: %w", p.Path, err)
+		return fmt.Errorf("creating plan backup file at %s: %w", p.path, err)
 	}
 	defer f.Close()
 
@@ -99,7 +99,7 @@ func (p Handler) WritePlan(optPlan OptimisationPlan) error {
 
 	_, err = f.Write(encodedPlan)
 	if err != nil {
-		return fmt.Errorf("writing plan to file at %s: %w", p.Path, err)
+		return fmt.Errorf("writing plan to file at %s: %w", p.path, err)
 	}
 
 	return nil

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -66,6 +66,9 @@ func NewHandler(logger *slog.Logger, path string) Handler {
 }
 
 func (p Handler) ReadPlan() (OptimisationPlan, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
 	content, err := os.ReadFile(p.Path)
 	if err != nil {
 		return OptimisationPlan{}, fmt.Errorf("reading plan from file: %w", err)

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -92,6 +92,7 @@ func TestRemoveExpiredIntervals(t *testing.T) {
 	tests := []test{
 		{startTime: 1715318999, expectedNum: 3},
 		{startTime: 1715319300, expectedNum: 2},
+		{startTime: 1715319899, expectedNum: 1},
 		{startTime: 1715319901, expectedNum: 0},
 	}
 
@@ -128,7 +129,8 @@ func TestGetCurrentInterval(t *testing.T) {
 	}
 
 	tests := []test{
-		{startTime: 1715318999, hasInterval: true, expectedMeterPower: 400},
+		{startTime: 1715318999, hasInterval: false, expectedMeterPower: 0},
+		{startTime: 1715319299, hasInterval: true, expectedMeterPower: 400},
 		{startTime: 1715319300, hasInterval: true, expectedMeterPower: 390},
 		{startTime: 1715319901, hasInterval: false, expectedMeterPower: 0},
 	}

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -83,44 +83,6 @@ func TestWritesAndReadsAPlan(t *testing.T) {
 	os.Remove(planPath)
 }
 
-func TestRemoveExpiredIntervals(t *testing.T) {
-	type test struct {
-		startTime   int
-		expectedNum int
-	}
-
-	tests := []test{
-		{startTime: 1715318999, expectedNum: 3},
-		{startTime: 1715319300, expectedNum: 2},
-		{startTime: 1715319899, expectedNum: 1},
-		{startTime: 1715319901, expectedNum: 0},
-	}
-
-	for i, tc := range tests {
-
-		planPath := fmt.Sprintf("/tmp/trim-plan-%d-%d.json", i, time.Now().Unix())
-
-		handler := plan.NewHandler(testLogger, planPath)
-
-		origPlan := GetOptimisationPlan()
-		assert.Len(t, origPlan.OptimisationIntervals, 3)
-
-		err := handler.WritePlan(origPlan)
-		assert.NoError(t, err)
-
-		startTime := time.Unix(int64(tc.startTime), 0)
-
-		err = handler.TrimPlan(startTime)
-		assert.NoError(t, err)
-
-		trimmedPlan, err := handler.ReadPlan()
-		assert.NoError(t, err)
-		assert.Len(t, trimmedPlan.OptimisationIntervals, tc.expectedNum)
-
-		os.Remove(planPath)
-	}
-}
-
 func TestGetCurrentInterval(t *testing.T) {
 	type test struct {
 		startTime          int

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -2,6 +2,7 @@ package plan_test
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"testing"
 	"time"
@@ -10,14 +11,46 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestWritesAndReadsAPlan(t *testing.T) {
-	optPlan := plan.OptimisationPlan{
+var testLogger = slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+func GetOptimisationPlan() plan.OptimisationPlan {
+	return plan.OptimisationPlan{
 		SiteID:       "test-site",
 		SetpointType: 1,
 		OptimisationIntervals: []plan.OptimisationInterval{
 			{
 				Interval: plan.OptimisationIntervalTimestamp{
 					StartTime: plan.OptimisationTimestamp{Seconds: 1715319000},
+					EndTime:   plan.OptimisationTimestamp{Seconds: 1715319300},
+				},
+				BatteryPower: plan.OptimisationValue{
+					Value: 100,
+					Unit:  2,
+				},
+				StateOfCharge: 0.55,
+				MeterPower: plan.OptimisationValue{
+					Value: 400,
+					Unit:  2,
+				},
+			},
+			{
+				Interval: plan.OptimisationIntervalTimestamp{
+					StartTime: plan.OptimisationTimestamp{Seconds: 1715319300},
+					EndTime:   plan.OptimisationTimestamp{Seconds: 1715319600},
+				},
+				BatteryPower: plan.OptimisationValue{
+					Value: 100,
+					Unit:  2,
+				},
+				StateOfCharge: 0.55,
+				MeterPower: plan.OptimisationValue{
+					Value: 400,
+					Unit:  2,
+				},
+			},
+			{
+				Interval: plan.OptimisationIntervalTimestamp{
+					StartTime: plan.OptimisationTimestamp{Seconds: 1715319600},
 					EndTime:   plan.OptimisationTimestamp{Seconds: 1715319900},
 				},
 				BatteryPower: plan.OptimisationValue{
@@ -32,11 +65,14 @@ func TestWritesAndReadsAPlan(t *testing.T) {
 			},
 		},
 	}
-	planPath := fmt.Sprintf("/tmp/plan-%d.json", time.Now().Unix())
+}
 
-	handler := plan.NewHandler(planPath)
+func TestWritesAndReadsAPlan(t *testing.T) {
+	planPath := fmt.Sprintf("/tmp/write-plan-%d.json", time.Now().Unix())
 
-	err := handler.WritePlan(optPlan)
+	handler := plan.NewHandler(testLogger, planPath)
+
+	err := handler.WritePlan(GetOptimisationPlan())
 	assert.NoError(t, err)
 
 	plan2, err := handler.ReadPlan()
@@ -45,4 +81,41 @@ func TestWritesAndReadsAPlan(t *testing.T) {
 	assert.Equal(t, plan2.OptimisationIntervals[0].BatteryPower.Value, float32(100))
 	assert.Equal(t, plan2.OptimisationIntervals[0].StateOfCharge, float32(0.55))
 	os.Remove(planPath)
+}
+
+func TestRemoveExpiredIntervals(t *testing.T) {
+	type test struct {
+		startTime   int
+		expectedNum int
+	}
+
+	tests := []test{
+		{startTime: 1715318999, expectedNum: 3},
+		{startTime: 1715319300, expectedNum: 2},
+		{startTime: 1715319901, expectedNum: 0},
+	}
+
+	for i, tc := range tests {
+
+		planPath := fmt.Sprintf("/tmp/trim-plan-%d-%d.json", i, time.Now().Unix())
+
+		handler := plan.NewHandler(testLogger, planPath)
+
+		origPlan := GetOptimisationPlan()
+		assert.Len(t, origPlan.OptimisationIntervals, 3)
+
+		err := handler.WritePlan(origPlan)
+		assert.NoError(t, err)
+
+		secondInterval := time.Unix(int64(tc.startTime), 0)
+
+		err = handler.TrimPlan(secondInterval)
+		assert.NoError(t, err)
+
+		trimmedPlan, err := handler.ReadPlan()
+		assert.NoError(t, err)
+		assert.Len(t, trimmedPlan.OptimisationIntervals, tc.expectedNum)
+
+		os.Remove(planPath)
+	}
 }

--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -1,0 +1,92 @@
+package publisher
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/EvergenEnergy/remote-standby/internal/config"
+	"github.com/EvergenEnergy/remote-standby/internal/plan"
+	mqtt "github.com/eclipse/paho.mqtt.golang"
+)
+
+type Service struct {
+	logger     *slog.Logger
+	cfg        config.Config
+	mqttClient mqtt.Client
+}
+
+func NewService(logger *slog.Logger, cfg config.Config, mqttClient mqtt.Client) *Service {
+	return &Service{
+		logger:     logger,
+		cfg:        cfg,
+		mqttClient: mqttClient,
+	}
+}
+
+type CommandPayload struct {
+	Action string  `json:"action"`
+	Value  float64 `json:"value"`
+}
+
+type ErrorPayload struct {
+	Category  string    `json:"category"`
+	Message   string    `json:"message"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+func (s *Service) PublishError(message string, receivedError error) {
+	s.logger.Error(message, "error", receivedError)
+
+	payload := ErrorPayload{
+		Category:  "Standby",
+		Message:   fmt.Sprintf("Error %s: %s", message, receivedError),
+		Timestamp: time.Now(),
+	}
+	encPayload, err := json.Marshal(payload)
+	if err != nil {
+		s.logger.Error("marshalling error payload", "error", err)
+	}
+
+	if s.cfg.MQTT.ErrorTopic == "" {
+		s.logger.Error("no error topic configured")
+	}
+	errTopic := fmt.Sprintf("%s/%s", s.cfg.MQTT.ErrorTopic, payload.Category)
+
+	s.mqttClient.Publish(errTopic, 1, false, encPayload)
+}
+
+func (s *Service) PublishCommand(optInterval plan.OptimisationInterval) error {
+	if s.cfg.MQTT.WriteCommandTopic == "" || s.cfg.MQTT.CommandAction == "" {
+		return fmt.Errorf("no command topic (%s) or action (%s) configured", s.cfg.MQTT.WriteCommandTopic, s.cfg.MQTT.CommandAction)
+	}
+
+	payload := BuildCommandPayload(s.cfg.MQTT.CommandAction, optInterval)
+	encPayload, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("marshalling command payload: %w", err)
+	}
+
+	s.mqttClient.Publish(s.cfg.MQTT.WriteCommandTopic, 1, false, encPayload)
+	return nil
+}
+
+func BuildCommandPayload(action string, optInterval plan.OptimisationInterval) CommandPayload {
+	meterValue := float64(optInterval.MeterPower.Value)
+	meterUnit := optInterval.MeterPower.Unit
+
+	var publishMeterValue float64
+	switch {
+	case meterUnit == 1:
+		publishMeterValue = meterValue / 1000
+	case meterUnit == 2:
+		publishMeterValue = meterValue
+	case meterUnit == 3:
+		publishMeterValue = meterValue * 1000
+	}
+	return CommandPayload{
+		Action: action,
+		Value:  publishMeterValue,
+	}
+}

--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -36,21 +36,25 @@ type ErrorPayload struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
+const errorCategory = "Standby"
+
 func (s *Service) PublishError(message string, receivedError error) {
 	s.logger.Error(message, "error", receivedError)
 
 	payload := ErrorPayload{
-		Category:  "Standby",
+		Category:  errorCategory,
 		Message:   fmt.Sprintf("Error %s: %s", message, receivedError),
 		Timestamp: time.Now(),
 	}
 	encPayload, err := json.Marshal(payload)
 	if err != nil {
 		s.logger.Error("marshalling error payload", "error", err)
+		return
 	}
 
 	if s.cfg.MQTT.ErrorTopic == "" {
 		s.logger.Error("no error topic configured")
+		return
 	}
 	errTopic := fmt.Sprintf("%s/%s", s.cfg.MQTT.ErrorTopic, payload.Category)
 

--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -36,13 +36,19 @@ type ErrorPayload struct {
 	Timestamp time.Time `json:"timestamp"`
 }
 
-const errorCategory = "Standby"
+const errorCategoryStandby = "Standby"
+
+const (
+	MeterPowerUnitWatt     = 1
+	MeterPowerUnitKilowatt = 2
+	MeterPowerUnitMegawatt = 3
+)
 
 func (s *Service) PublishError(message string, receivedError error) {
 	s.logger.Error(message, "error", receivedError)
 
 	payload := ErrorPayload{
-		Category:  errorCategory,
+		Category:  errorCategoryStandby,
 		Message:   fmt.Sprintf("Error %s: %s", message, receivedError),
 		Timestamp: time.Now(),
 	}
@@ -82,11 +88,11 @@ func BuildCommandPayload(action string, optInterval plan.OptimisationInterval) C
 
 	var publishMeterValue float64
 	switch {
-	case meterUnit == 1:
+	case meterUnit == MeterPowerUnitWatt:
 		publishMeterValue = meterValue / 1000
-	case meterUnit == 2:
+	case meterUnit == MeterPowerUnitKilowatt:
 		publishMeterValue = meterValue
-	case meterUnit == 3:
+	case meterUnit == MeterPowerUnitMegawatt:
 		publishMeterValue = meterValue * 1000
 	}
 	return CommandPayload{

--- a/internal/publisher/publisher_test.go
+++ b/internal/publisher/publisher_test.go
@@ -1,0 +1,30 @@
+package publisher_test
+
+import (
+	"testing"
+
+	"github.com/EvergenEnergy/remote-standby/internal/plan"
+	"github.com/EvergenEnergy/remote-standby/internal/publisher"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildCommandPayloads(t *testing.T) {
+	type test struct {
+		meterPower float32
+		meterUnit  int
+		expected   float64
+	}
+
+	tests := []test{
+		{meterPower: 1234, meterUnit: 1, expected: 1.234},
+		{meterPower: 1234, meterUnit: 2, expected: 1234},
+		{meterPower: 1.234, meterUnit: 3, expected: 1234},
+	}
+
+	for _, tc := range tests {
+		payload := publisher.BuildCommandPayload("actionvalue", plan.OptimisationInterval{
+			MeterPower: plan.OptimisationValue{Value: tc.meterPower, Unit: tc.meterUnit},
+		})
+		assert.InDelta(t, tc.expected, payload.Value, 0.0001)
+	}
+}

--- a/internal/standby/standby.go
+++ b/internal/standby/standby.go
@@ -62,7 +62,7 @@ func (s *Service) handlePlanMessage(client mqtt.Client, msg mqtt.Message) {
 	optPlan := plan.OptimisationPlan{}
 
 	err := json.Unmarshal(msg.Payload(), &optPlan)
-	if err == nil && optPlan.IsEmpty(s.logger) {
+	if err == nil && optPlan.IsEmpty() {
 		err = fmt.Errorf("optimisation plan is empty")
 	}
 	if err != nil {

--- a/internal/standby/standby.go
+++ b/internal/standby/standby.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/EvergenEnergy/remote-standby/internal/config"
 	"github.com/EvergenEnergy/remote-standby/internal/plan"
+	"github.com/EvergenEnergy/remote-standby/internal/publisher"
 	"github.com/EvergenEnergy/remote-standby/internal/storage"
 	mqtt "github.com/eclipse/paho.mqtt.golang"
 )
@@ -22,22 +23,26 @@ const (
 )
 
 type Service struct {
-	logger     *slog.Logger
-	cfg        config.Config
-	mqttClient mqtt.Client
-	storageSvc *storage.Service
-	mutex      *sync.Mutex
-	mode       ServiceMode
+	logger      *slog.Logger
+	cfg         config.Config
+	mqttClient  mqtt.Client
+	storageSvc  *storage.Service
+	publisher   *publisher.Service
+	planHandler plan.PlanHandler
+	mutex       *sync.Mutex
+	mode        ServiceMode
 }
 
-func NewService(logger *slog.Logger, cfg config.Config, storage *storage.Service, mqttClient mqtt.Client) *Service {
+func NewService(logger *slog.Logger, cfg config.Config, storage *storage.Service, publisher *publisher.Service, mqttClient mqtt.Client) *Service {
 	return &Service{
-		logger:     logger,
-		cfg:        cfg,
-		mqttClient: mqttClient,
-		storageSvc: storage,
-		mutex:      new(sync.Mutex),
-		mode:       StandbyMode,
+		logger:      logger,
+		cfg:         cfg,
+		mqttClient:  mqttClient,
+		storageSvc:  storage,
+		publisher:   publisher,
+		mutex:       new(sync.Mutex),
+		mode:        StandbyMode,
+		planHandler: plan.NewHandler(logger, cfg.Standby.BackupFile),
 	}
 }
 
@@ -48,7 +53,7 @@ func (s *Service) subscribeToTopic(topic string, handler mqtt.MessageHandler) {
 }
 
 func (s *Service) handleCommandMessage(client mqtt.Client, msg mqtt.Message) {
-	s.logger.Debug(fmt.Sprintf("Received message: %s from topic: %s", msg.Payload(), msg.Topic()))
+	s.logger.Debug(fmt.Sprintf("Received command: %s from topic: %s", msg.Payload(), msg.Topic()))
 	s.storageSvc.SetCommandTimestamp(time.Now())
 }
 
@@ -61,13 +66,13 @@ func (s *Service) handlePlanMessage(client mqtt.Client, msg mqtt.Message) {
 		err = fmt.Errorf("optimisation plan is empty")
 	}
 	if err != nil {
-		s.publishError("reading optimisation plan", err)
+		s.publisher.PublishError("reading optimisation plan", err)
 	}
 
-	handler := plan.NewHandler(s.cfg.Standby.BackupFile)
+	handler := plan.NewHandler(s.logger, s.cfg.Standby.BackupFile)
 	err = handler.WritePlan(optPlan)
 	if err != nil {
-		s.publishError("writing optimisation plan", err)
+		s.publisher.PublishError("writing optimisation plan", err)
 	}
 }
 
@@ -107,15 +112,27 @@ func (s *Service) runDetector(ctx context.Context) {
 func (s *Service) CheckForOutage(currentTime time.Time) {
 	outageThreshold := s.cfg.Standby.OutageThreshold
 	timeSinceLastCmd := currentTime.Sub(s.storageSvc.GetCommandTimestamp())
-	s.logger.Debug("checking", "time since last command", timeSinceLastCmd)
+	s.logger.Debug("checking", "time since last command", timeSinceLastCmd, "current mode", s.getMode(), "currentTime", currentTime)
 	if timeSinceLastCmd > outageThreshold {
 		if s.InStandbyMode() {
 			s.logger.Info("Outage detected", "config threshold", outageThreshold, "time since last command", timeSinceLastCmd)
 			s.setMode(CommandMode)
 		} else {
 			s.logger.Debug("Ongoing outage", "config threshold", outageThreshold, "time since last command", timeSinceLastCmd)
+			err := s.planHandler.TrimPlan(currentTime)
+			if err != nil {
+				s.publisher.PublishError("trimming the plan", err)
+			}
 		}
-		// TODO: Trigger a process to identify closest optimisation command from plan and send it
+		currentInterval, err := s.planHandler.GetCurrentInterval(currentTime)
+		if err != nil {
+			s.publisher.PublishError("getting current command", err)
+			return
+		}
+		err = s.publisher.PublishCommand(currentInterval)
+		if err != nil {
+			s.publisher.PublishError("publishing current command", err)
+		}
 	} else {
 		if s.InCommandMode() {
 			s.logger.Info("Commands resumed after outage", "time since last command", timeSinceLastCmd)
@@ -134,30 +151,6 @@ func (s *Service) Start(ctx context.Context) error {
 
 func (s *Service) Stop() {
 	s.stopMQTT()
-}
-
-type ErrorPayload struct {
-	Category  string    `json:"category"`
-	Message   string    `json:"message"`
-	Timestamp time.Time `json:"timestamp"`
-}
-
-func (s *Service) publishError(message string, receivedError error) {
-	s.logger.Error(message, "error", receivedError)
-
-	payload := ErrorPayload{
-		Category:  "Standby",
-		Message:   fmt.Sprintf("Error %s: %s", message, receivedError),
-		Timestamp: time.Now(),
-	}
-	encPayload, err := json.Marshal(payload)
-	if err != nil {
-		s.logger.Error("marshalling error payload", "error", err)
-	}
-
-	errTopic := fmt.Sprintf("%s/%s", s.cfg.MQTT.ErrorTopic, payload.Category)
-
-	s.mqttClient.Publish(errTopic, 1, false, encPayload)
 }
 
 func (s *Service) setMode(newMode ServiceMode) {

--- a/internal/standby/standby_test.go
+++ b/internal/standby/standby_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/EvergenEnergy/remote-standby/internal/config"
 	mqtt "github.com/EvergenEnergy/remote-standby/internal/mqtt"
 	"github.com/EvergenEnergy/remote-standby/internal/plan"
+	"github.com/EvergenEnergy/remote-standby/internal/publisher"
 	"github.com/EvergenEnergy/remote-standby/internal/standby"
 	"github.com/EvergenEnergy/remote-standby/internal/storage"
 	pahoMQTT "github.com/eclipse/paho.mqtt.golang"
@@ -27,10 +28,12 @@ var (
 func getTestConfig() config.Config {
 	return config.Config{
 		MQTT: config.MQTTConfig{
-			BrokerURL:        "tcp://localhost:1883",
-			StandbyTopic:     "cmd/site/standby/serial/plan",
-			ErrorTopic:       "cmd/site/error/serial/error",
-			ReadCommandTopic: "cmd/site/handler/serial/cloud",
+			BrokerURL:         "tcp://localhost:1883",
+			StandbyTopic:      "cmd/site/standby/serial/plan",
+			ErrorTopic:        "cmd/site/error/serial/error",
+			ReadCommandTopic:  "cmd/site/handler/serial/cloud",
+			WriteCommandTopic: "cmd/site/handler/serial/standby",
+			CommandAction:     "STORAGEPOINT",
 		},
 		Standby: config.StandbyConfig{
 			CheckInterval:   time.Duration(1 * time.Second),
@@ -47,7 +50,8 @@ func TestUpdatesTimestamp_Integration(t *testing.T) {
 	cfg := getTestConfig()
 	mqttClient := mqtt.NewClient(cfg)
 	storageSvc := storage.NewService(testLogger)
-	svc := standby.NewService(testLogger, cfg, storageSvc, mqttClient)
+	publisherSvc := publisher.NewService(testLogger, cfg, mqttClient)
+	svc := standby.NewService(testLogger, cfg, storageSvc, publisherSvc, mqttClient)
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
@@ -88,7 +92,8 @@ func TestPublishesError_Integration(t *testing.T) {
 	cfg := getTestConfig()
 	mqttClient := mqtt.NewClient(cfg)
 	storageSvc := storage.NewService(testLogger)
-	svc := standby.NewService(testLogger, cfg, storageSvc, mqttClient)
+	publisherSvc := publisher.NewService(testLogger, cfg, mqttClient)
+	svc := standby.NewService(testLogger, cfg, storageSvc, publisherSvc, mqttClient)
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
@@ -107,49 +112,88 @@ func TestPublishesError_Integration(t *testing.T) {
 	assert.True(t, getErr())
 }
 
-var optPlan = plan.OptimisationPlan{
-	SiteID:       "test-site",
-	SetpointType: 1,
-	OptimisationIntervals: []plan.OptimisationInterval{
-		{
-			Interval: plan.OptimisationIntervalTimestamp{
-				StartTime: plan.OptimisationTimestamp{Seconds: 1715319000},
-				EndTime:   plan.OptimisationTimestamp{Seconds: 1715319900},
-			},
-			BatteryPower: plan.OptimisationValue{
-				Value: 100,
-				Unit:  2,
-			},
-			StateOfCharge: 0.55,
-			MeterPower: plan.OptimisationValue{
-				Value: 400,
-				Unit:  2,
+func getOptPlan() plan.OptimisationPlan {
+	return plan.OptimisationPlan{
+		SiteID:       "test-site",
+		SetpointType: 1,
+		OptimisationIntervals: []plan.OptimisationInterval{
+			{
+				Interval: plan.OptimisationIntervalTimestamp{
+					StartTime: plan.OptimisationTimestamp{Seconds: 1715319000},
+					EndTime:   plan.OptimisationTimestamp{Seconds: 1715319900},
+				},
+				BatteryPower: plan.OptimisationValue{
+					Value: 100,
+					Unit:  2,
+				},
+				StateOfCharge: 0.55,
+				MeterPower: plan.OptimisationValue{
+					Value: 400,
+					Unit:  2,
+				},
 			},
 		},
-	},
+	}
 }
 
 func TestStoresAPlan_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode.")
 	}
+	var commandMsg pahoMQTT.Message
+	mu := new(sync.Mutex)
+
+	getMsg := func() pahoMQTT.Message {
+		mu.Lock()
+		defer mu.Unlock()
+		return commandMsg
+	}
+	setMsg := func(msg pahoMQTT.Message) {
+		mu.Lock()
+		defer mu.Unlock()
+		commandMsg = msg
+	}
+
 	cfg := getTestConfig()
 	mqttClient := mqtt.NewClient(cfg)
 	storageSvc := storage.NewService(testLogger)
-	svc := standby.NewService(testLogger, cfg, storageSvc, mqttClient)
+	publisherSvc := publisher.NewService(testLogger, cfg, mqttClient)
+	svc := standby.NewService(testLogger, cfg, storageSvc, publisherSvc, mqttClient)
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 	err := svc.Start(ctx)
 	assert.NoError(t, err)
 
+	mqttClient.Subscribe(cfg.MQTT.WriteCommandTopic, 1, func(client pahoMQTT.Client, msg pahoMQTT.Message) {
+		setMsg(msg)
+	})
+
+	// Set the first interval in the optimisation plan to be 10 seconds from now, and publish it
+	currentTime := time.Now()
+	targetTime := currentTime.Add(10 * time.Second)
+	t.Log("Adjusting interval start time to ", "targetTime", targetTime)
+	optPlan := getOptPlan()
+	optPlan.OptimisationIntervals[0].Interval.StartTime.Seconds = targetTime.Unix()
+	optPlan.OptimisationIntervals[0].Interval.EndTime.Seconds = targetTime.Add(300 * time.Second).Unix()
+
 	encPayload, _ := json.Marshal(optPlan)
 	token := mqttClient.Publish(cfg.MQTT.StandbyTopic, 1, false, encPayload)
 	token.Wait()
-	time.Sleep(time.Second)
 
-	// TODO once plan replay is implemented, add asserts to indicate we've read the plan
+	// wait for the service to detect an outage and send a replacement command
+	time.Sleep(4 * time.Second)
 	svc.Stop()
+
+	subscribedMsg := getMsg()
+	assert.NotEmpty(t, subscribedMsg)
+
+	msg := publisher.CommandPayload{}
+	err = json.Unmarshal(subscribedMsg.Payload(), &msg)
+	assert.NoError(t, err)
+
+	assert.EqualValues(t, cfg.MQTT.CommandAction, msg.Action)
+	assert.EqualValues(t, optPlan.OptimisationIntervals[0].MeterPower.Value, msg.Value)
 }
 
 func TestDetectsOutage_Integration(t *testing.T) {
@@ -160,7 +204,8 @@ func TestDetectsOutage_Integration(t *testing.T) {
 	cfg := getTestConfig()
 	mqttClient := mqtt.NewClient(cfg)
 	storageSvc := storage.NewService(testLogger)
-	svc := standby.NewService(testLogger, cfg, storageSvc, mqttClient)
+	publisher := publisher.NewService(testLogger, cfg, mqttClient)
+	svc := standby.NewService(testLogger, cfg, storageSvc, publisher, mqttClient)
 
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
@@ -182,11 +227,11 @@ func TestDetectsOutage_Integration(t *testing.T) {
 	svc.CheckForOutage(time.Now())
 	assert.True(t, svc.InCommandMode())
 
-	encPayload, _ := json.Marshal(map[string]interface{}{"action": "test", "value": 23})
+	encPayload, _ := json.Marshal(map[string]interface{}{"action": "fromTest", "value": 23})
 	token := mqttClient.Publish(cfg.MQTT.ReadCommandTopic, 1, false, encPayload)
 	token.Wait()
+	testLogger.Info("Test published new cloud cmd to", "topic", cfg.MQTT.ReadCommandTopic)
 	time.Sleep(time.Second)
-	testLogger.Info("published to", "topic", cfg.MQTT.ReadCommandTopic)
 
 	// After 4 seconds, new command received, resume standby mode
 	svc.CheckForOutage(time.Now())

--- a/internal/standby/standby_test.go
+++ b/internal/standby/standby_test.go
@@ -136,7 +136,7 @@ func getOptPlan() plan.OptimisationPlan {
 	}
 }
 
-func TestStoresAPlan_Integration(t *testing.T) {
+func TestStoresAndReplaysAPlan_Integration(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping integration test in short mode.")
 	}
@@ -169,9 +169,9 @@ func TestStoresAPlan_Integration(t *testing.T) {
 		setMsg(msg)
 	})
 
-	// Set the first interval in the optimisation plan to be 10 seconds from now, and publish it
+	// Set the first interval in the optimisation plan to start 10 seconds ago, and publish it
 	currentTime := time.Now()
-	targetTime := currentTime.Add(10 * time.Second)
+	targetTime := currentTime.Add(-10 * time.Second)
 	t.Log("Adjusting interval start time to ", "targetTime", targetTime)
 	optPlan := getOptPlan()
 	optPlan.OptimisationIntervals[0].Interval.StartTime.Seconds = targetTime.Unix()

--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/EvergenEnergy/remote-standby/internal/config"
 	internalMQTT "github.com/EvergenEnergy/remote-standby/internal/mqtt"
+	"github.com/EvergenEnergy/remote-standby/internal/publisher"
 	"github.com/EvergenEnergy/remote-standby/internal/standby"
 	"github.com/EvergenEnergy/remote-standby/internal/storage"
 	"github.com/EvergenEnergy/remote-standby/internal/worker"
@@ -37,7 +38,8 @@ func main() {
 
 	mqttClient := internalMQTT.NewClient(cfg)
 	storageService := storage.NewService(logger)
-	standbyService := standby.NewService(logger, cfg, storageService, mqttClient)
+	publisher := publisher.NewService(logger, cfg, mqttClient)
+	standbyService := standby.NewService(logger, cfg, storageService, publisher, mqttClient)
 	standbyWorker := worker.NewWorker(logger, cfg, standbyService)
 
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, os.Interrupt)

--- a/tests/integration/config.yaml
+++ b/tests/integration/config.yaml
@@ -2,8 +2,10 @@ logging:
   level: debug
 mqtt:
   broker_url: "tcp://mosquitto:1883"
-  write_command_topic: "cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/#"
-  read_command_topic: "cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/#"
+  read_command_topic: "cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/cloud"
+  write_command_topic: "cmd/${SITE_NAME}/handler/${SERIAL_NUMBER}/standby"
   standby_topic: "cmd/${SITE_NAME}/standby/${SERIAL_NUMBER}/plan"
+  error_topic: "dt/${SITE_NAME}/error/${SERIAL_NUMBER}"
+  command_action: "STORAGE_POINT"
 standby:
   backup_file: "/command-standby/backup/plan.json"

--- a/tests/mosquitto/mosquitto.conf
+++ b/tests/mosquitto/mosquitto.conf
@@ -1,7 +1,7 @@
 allow_anonymous true
 autosave_interval 10
 listener 1883
-log_type all
+log_type notice
 max_inflight_bytes 0
 max_inflight_messages 50
 max_queued_bytes 1073741824


### PR DESCRIPTION
Changes to read data from a stored optimisation plan and publish commands:
- add config value for the command payload action
- move MQTT publishing (for commands and errors) into separate package
- during outage, clean up stored plan to remove expired intervals on each pass
- during outage, select first current interval from plan and publish
- add unit conversion to ensure we always publish in kW
- add tests
