### PR TITLE
Publish message as a list of commands

### DIFF
--- a/internal/publisher/publisher.go
+++ b/internal/publisher/publisher.go
@@ -74,7 +74,7 @@ func (s *Service) PublishCommand(optInterval plan.OptimisationInterval) error {
 		return fmt.Errorf("no command topic (%s) or action (%s) configured", s.cfg.MQTT.WriteCommandTopic, s.cfg.MQTT.CommandAction)
 	}
 
-	payload := BuildCommandPayload(s.cfg.MQTT.CommandAction, optInterval)
+	payload := []CommandPayload{BuildCommandPayload(s.cfg.MQTT.CommandAction, optInterval)}
 
 	encPayload, err := json.Marshal(payload)
 	if err != nil {

--- a/internal/standby/standby_test.go
+++ b/internal/standby/standby_test.go
@@ -208,9 +208,13 @@ func TestStoresAndReplaysAPlan_Integration(t *testing.T) {
 	subscribedMsg := getMsg()
 	assert.NotEmpty(t, subscribedMsg)
 
-	msg := publisher.CommandPayload{}
-	err = json.Unmarshal(subscribedMsg.Payload(), &msg)
+	msgList := []publisher.CommandPayload{}
+	err = json.Unmarshal(subscribedMsg.Payload(), &msgList)
 	assert.NoError(t, err)
+
+	assert.Equal(t, 1, len(msgList))
+
+	msg := msgList[0]
 
 	assert.EqualValues(t, cfg.MQTT.CommandAction, msg.Action)
 	assert.EqualValues(t, optPlan.OptimisationIntervals[0].MeterPower.Value, msg.Value)


### PR DESCRIPTION
This is the counterpart change to https://github.com/EvergenEnergy/remote-commands-handler/pull/67

When publishing a command from the optimisation plan via MQTT, send it as a JSON list which could hypothetically include multiple commands.