### PR TITLE
remove coveralls to avoid pipeline errors

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,14 +29,6 @@ jobs:
       - name: Run integration tests
         run: make test.integration
 
-      - name: Install goveralls
-        run: go install github.com/mattn/goveralls@latest
-
-      - name: Send coverage
-        env:
-          COVERALLS_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-        run: goveralls -coverprofile=covprofile.unit,covprofile.int -service=github
-
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 This service operates as a backup controller for [remote-commands-handler](github.com/EvergenEnergy/remote-commands-handler). If it detects a lack of commands arriving for the handler to process, it will step in and issue commands in order to maintain a basic level of control.
 
-[![Coverage Status](https://coveralls.io/repos/github/EvergenEnergy/remote-standby/badge.svg?branch=main)](https://coveralls.io/github/EvergenEnergy/remote-standby?branch=main)
-
 ## Getting Started
 
 All dependencies can be run using docker compose. To run locally, create your own `.env` file.


### PR DESCRIPTION
Coveralls appears to be correctly configured but is causing errors, removing in order to allow dependency updates